### PR TITLE
fix critical Timing bug

### DIFF
--- a/src/main/java/de/jonas/stuff/listener/BossBarTimer.java
+++ b/src/main/java/de/jonas/stuff/listener/BossBarTimer.java
@@ -15,8 +15,7 @@ public class BossBarTimer implements Listener {
     }
 
     @EventHandler
-    public void onJoin(PlayerQuitEvent e) {
-        e.getPlayer().hideBossBar(Stuff.INSTANCE.timerHandler.getBar());
+    public void onQuit(PlayerQuitEvent e) {
+        if (Stuff.INSTANCE.timerHandler.barAktive()) e.getPlayer().hideBossBar(Stuff.INSTANCE.timerHandler.getBar());
     }
-    
 }

--- a/src/main/java/de/jonas/stuff/utility/Timing.java
+++ b/src/main/java/de/jonas/stuff/utility/Timing.java
@@ -40,6 +40,11 @@ public class Timing {
         float tickrate = Bukkit.getServer().getServerTickManager().getTickRate();
         float ticks = ((float) delay.toMillis() / 1_000f) * tickrate;
 
+        if (ticks < 1) {
+            // prevent an infinit Loop in same Tick
+            throw new IllegalStateException("Can't run a Timer With Period of <1 Tick; delay=" + delay.toString() + ", plugin=" + plugin.getName());
+        }
+
         holder.task = Bukkit.getScheduler().runTaskLater(plugin, () -> {
             runTaskTimer(delay, plugin, task, holder);
             task.run();

--- a/src/main/java/de/jonas/stuff/utility/Timing.java
+++ b/src/main/java/de/jonas/stuff/utility/Timing.java
@@ -7,18 +7,18 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitTask;
 
-public class Timing {    
+public class Timing {
 
-    private static void runTaskLater(Instant time, Plugin plugin, Runnable task, TaskHolder holder) {    
+    private static void runTaskLater(Instant time, Plugin plugin, Runnable task, TaskHolder holder) {
         float tickrate = Bukkit.getServer().getServerTickManager().getTickRate();
         long delay = time.toEpochMilli() - System.currentTimeMillis();
-        float ticks = (delay / 1_000 / tickrate);
-         
+        float ticks = ((float) delay / 1_000f) * tickrate;
+
         if (ticks < 1) {
             task.run();
         } else {
             if (ticks > 20) {
-                // 20 doesn´t mean 1 second
+                // 20 doesn't mean 1 second
                 ticks = Math.max(ticks / 20, 20f);
                 // Every 5 minutes we recalculate because of different tps
                 ticks = Math.min(ticks, tickrate * 300);
@@ -38,14 +38,14 @@ public class Timing {
 
     public static void runTaskTimer(Duration delay, Plugin plugin, Runnable task, TaskHolder holder) {
         float tickrate = Bukkit.getServer().getServerTickManager().getTickRate();
-        float ticks = (delay.toMillis() / 1_000 / tickrate);
+        float ticks = ((float) delay.toMillis() / 1_000f) * tickrate;
 
         holder.task = Bukkit.getScheduler().runTaskLater(plugin, () -> {
-            task.run();
             runTaskTimer(delay, plugin, task, holder);
+            task.run();
         }, (long) ticks);
-    } 
-    
+    }
+
     public static TaskHolder runTaskTimer(Duration delay, Plugin plugin, Runnable task) {
         TaskHolder holder = new TaskHolder();
         runTaskTimer(delay, plugin, task, holder);
@@ -55,5 +55,4 @@ public class Timing {
     public static class TaskHolder {
         public BukkitTask task;
     }
-
 }


### PR DESCRIPTION
- Fixes a critical bug in `utility.Timing`
- better cancleation of `utility.Timing.runTaskTimer`
- subsecond precision in `utility.Timing`
- prevented a infinit Loop in the same Tick in `utility.tunTaskTimer`
- prevented a NullpointerException in `listener.BossBarTimer`
- renamed quit listener of `listener.BossBarTimer` to `onQuit`

untested